### PR TITLE
email validation: replace regex with python library

### DIFF
--- a/kompy/komoot_connector.py
+++ b/kompy/komoot_connector.py
@@ -50,7 +50,7 @@ class KomootConnector:
         :param email: email address used to log in to Komoot
         :param password: password used to log in to Komoot
         """
-        if not '@' in parseaddr(email)[1]:
+        if '@' not in parseaddr(email)[1]:
             raise NotEmailError(email)
 
         self.authentication = Authentication(

--- a/kompy/komoot_connector.py
+++ b/kompy/komoot_connector.py
@@ -14,6 +14,7 @@ import gpxpy
 import requests
 from fit_tool.fit_file import FitFile
 from gpxpy.gpx import GPX
+from email.utils import parseaddr
 
 from kompy.authentication import Authentication
 from kompy.constants.activities import SupportedActivities
@@ -49,10 +50,7 @@ class KomootConnector:
         :param email: email address used to log in to Komoot
         :param password: password used to log in to Komoot
         """
-        if not re.match(
-            pattern=r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b',
-            string=email,
-        ):
+        if not '@' in parseaddr(email)[1]:
             raise NotEmailError(email)
 
         self.authentication = Authentication(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Kompy"
-version = "0.0.9"
+version = "0.0.10"
 authors = [
     { name = "Matteo Villosio", email = "github@matteovillosio.com" },
 ]


### PR DESCRIPTION
Perform email validation with python library instead of using a regex. The regex did not accept RFC 5322 email adresses such at user+domain@example.com