### PR TITLE
Add privacy status "friends"

### DIFF
--- a/kompy/constants/privacy_status.py
+++ b/kompy/constants/privacy_status.py
@@ -7,3 +7,4 @@ class PrivacyStatus:
     """
     PUBLIC: Final[str] = 'public'
     PRIVATE: Final[str] = 'private'
+    FRIENDS: Final[str] = 'friends'

--- a/kompy/komoot_connector.py
+++ b/kompy/komoot_connector.py
@@ -331,8 +331,9 @@ class KomootConnector:
         json = {
             'sport': activity_type,
             'name': tour_name,
-            'status': status
         }
+        if status is not None:
+            json['status'] = status
         resp = requests.patch(
             url=KomootUrl.TOUR_URL.format(tour_identifier=tour_id),
             auth=(self.authentication.get_email_address(), self.authentication.get_password()),

--- a/kompy/komoot_connector.py
+++ b/kompy/komoot_connector.py
@@ -261,6 +261,7 @@ class KomootConnector:
         activity_type: str,
         tour_name: str,
         time_in_motion: Optional[int] = None,
+        status: Optional[str] = PrivacyStatus.FRIENDS
     ) -> bool:
         """
         Upload a tour. It can be either a GPX or FIT file.
@@ -270,6 +271,7 @@ class KomootConnector:
         :param time_in_motion: Only exists for GPX files, in other file types this can be specified in the file itself.
         The time in motion in seconds. This is the time the user was active, so the overall duration minus the pauses.
         It must not be larger than the overall duration of the tour.
+        :param status: The privacy status of the tour, optional. If not provided, PrivacyStatus.FRIENDS will be used.
         :return: Whether the upload was successful
         """
         headers = {
@@ -277,6 +279,7 @@ class KomootConnector:
         }
         params = {
             'sport': activity_type,
+            'status': status,
         }
         if isinstance(tour_object, GPX):
             params['data_type'] = 'gpx'
@@ -307,13 +310,15 @@ class KomootConnector:
         self,
         tour_id: int,
         activity_type: Optional[str] = None,
-        tour_name: Optional[str] = None
+        tour_name: Optional[str] = None,
+        status: Optional[str] = None
     ) -> bool:
         """
         Change an existing tour.
         :param tour_id: The id of the existing tour
         :param activity_type: The new sport type, one of SupportedActivities, optional
         :param tour_name: The new name of the tour, optional
+        :param status: The new privacy status of the existing tour, one of PrivacyStatus, optional
         :return: Whether changing the tour was successful
         """
 
@@ -325,7 +330,8 @@ class KomootConnector:
 
         json = {
             'sport': activity_type,
-            'name': tour_name
+            'name': tour_name,
+            'status': status
         }
         resp = requests.patch(
             url=KomootUrl.TOUR_URL.format(tour_identifier=tour_id),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Kompy"
-version = "0.0.11"
+version = "0.0.12"
 authors = [
     { name = "Matteo Villosio", email = "github@matteovillosio.com" },
 ]

--- a/tests/test_komoot_connector.py
+++ b/tests/test_komoot_connector.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock
 import gpxpy
 
 from kompy import KomootConnector, Tour
+from kompy.constants.privacy_status import PrivacyStatus
 from tests.resources.mock_response_builder import mock_response_builder
 
 
@@ -71,7 +72,7 @@ class TestKomootConnector(unittest.TestCase):
             json_file_path=f'{os.path.dirname(os.path.realpath(__file__))}/resources/dummy_response_with_id.json',
         )
         gpx_data = gpxpy.parse(open(f'{os.path.dirname(os.path.realpath(__file__))}/resources/example.gpx'))
-        ret = self.connector.upload_tour(gpx_data, "Example gpx", "hike")
+        ret = self.connector.upload_tour(gpx_data, "Example gpx", "hike", PrivacyStatus.PRIVATE)
         self.assertEqual(ret, True)
 
     @patch('requests.patch')
@@ -81,7 +82,7 @@ class TestKomootConnector(unittest.TestCase):
             mock_status_code=200,
             json_file_path=f'{os.path.dirname(os.path.realpath(__file__))}/resources/dummy_response_with_id.json',
         )
-        ret = self.connector.change_tour(self.valid_id, "test name", "test type")
+        ret = self.connector.change_tour(self.valid_id, "test name", "test type", PrivacyStatus.PRIVATE)
         self.assertEqual(ret, True)
 
     @patch('requests.delete')


### PR DESCRIPTION
Komoot supports a 3rd privacy statuses besides `public` and `private`: `friends`

This adds this status and makes it usable in `upload_tour` and `change_tour` in `Connector`

Needs adaption of tests, therefore waiting for https://github.com/Tsadoq/kompy/pull/21 to be merged