### PR TITLE
Fix CI/CD pipeline and PyPI publish failures

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,9 +9,8 @@
 name: Upload Python Package to PyPI
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "Kompy"
-version = "0.0.12"
+name = "kompy"
+version = "0.0.13"
 authors = [
     { name = "Matteo Villosio", email = "github@matteovillosio.com" },
 ]


### PR DESCRIPTION
## Summary
- Fix `fit_tool` version pin (0.9.13 unavailable → 0.9.14)
- Extract `_validate_sport_types` helper to bring `get_tours` cyclomatic complexity under flake8 limit of 25
- Lowercase package name (`Kompy` → `kompy`) for PyPI normalization
- Bump version to 0.0.13 to avoid re-upload 400 error
- Change publish workflow trigger from every push to `main` to GitHub release events only

## Test plan
- [ ] `new_code_checks` workflow passes (flake8 + tests)
- [ ] `docs-generation` workflow passes
- [ ] `python-publish` workflow no longer triggers on push to main — verify it only fires on a GitHub Release