### PR TITLE
Bump deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/docs-generation.yml
+++ b/.github/workflows/docs-generation.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - run: pip install -r requirements.txt
       - run: pdoc -d restructuredtext kompy -o docs/
 
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/
 
@@ -37,4 +37,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Install dependencies


### PR DESCRIPTION
## Summary
- `upload-pages-artifact` v2 → v3 (v2 internally uses `upload-artifact@v3` which is now deprecated/blocked)
- `deploy-pages` v2 → v4
- `setup-python` v4 → v5 (docs workflow)
- `checkout` v3 → v4, `setup-python` v3 → v5 (publish workflow)

## Test plan
- [ ] `build documentation` workflow passes without deprecation errors
- [ ] `Upload Python Package to PyPI` workflow passes on next release